### PR TITLE
Make boards real

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ from quart import Quart
 
 import config
 import postgres
-from blueprints import user, login, post, api
+from blueprints import user, login, post, api, board
 
 app = Quart(__name__)
 app.jinja_env.globals.update(md=markdown.markdown)
@@ -34,6 +34,7 @@ async def init():
 
 
 app.register_blueprint(post.blue, "/post")
+app.register_blueprint(board.blue, "/board")
 app.register_blueprint(login.blue, "/")
 app.register_blueprint(user.blue, "/user")
 # API MUST BE LAST

--- a/blueprints/board/__init__.py
+++ b/blueprints/board/__init__.py
@@ -1,3 +1,5 @@
 from quart import Blueprint
 
 blue = Blueprint("board", __name__)
+
+from . import views

--- a/blueprints/board/__init__.py
+++ b/blueprints/board/__init__.py
@@ -1,0 +1,3 @@
+from quart import Blueprint
+
+blue = Blueprint("board", __name__)

--- a/blueprints/board/views.py
+++ b/blueprints/board/views.py
@@ -1,0 +1,12 @@
+import quart
+
+import postgres
+from . import blue
+
+
+@blue.route("/<board>")
+async def show_board(board: str):
+    newest = await postgres.pool.fetch(
+        "SELECT * FROM posts WHERE board <@ $1 ORDER BY timestamp DESC LIMIT 25", board
+    )
+    return await quart.render_template("front_page.html", pageposts=newest)

--- a/blueprints/board/views.py
+++ b/blueprints/board/views.py
@@ -1,3 +1,4 @@
+import flask_login
 import quart
 
 import postgres
@@ -12,3 +13,26 @@ async def show_board(board: str):
     return await quart.render_template(
         "board/board.html", board=board, pageposts=newest
     )
+
+
+@blue.route("/create", ["GET", "POST"])
+@flask_login.login_required
+async def create_board():
+    if quart.request.method == "GET":
+        return await quart.render_template("board/creation.html")
+
+    try:
+        path = (await quart.request.form)["path"]
+    except KeyError:
+        await quart.flash("no board given")
+        return await quart.render_template("board/creation.html")
+    viable_child = (
+        await postgres.pool.fetchrow("SELECT $1 <@ ANY(SELECT path FROM boards)", path)
+    )["?column?"]
+    if viable_child:
+        await postgres.pool.execute(
+            "INSERT INTO boards (path, creator) VALUES ($1, $2)",
+            path,
+            flask_login.current_user.id,
+        )
+        return quart.redirect(quart.url_for("board.show_board", board=path))

--- a/blueprints/board/views.py
+++ b/blueprints/board/views.py
@@ -9,4 +9,6 @@ async def show_board(board: str):
     newest = await postgres.pool.fetch(
         "SELECT * FROM posts WHERE board <@ $1 ORDER BY timestamp DESC LIMIT 25", board
     )
-    return await quart.render_template("board/board.html", board=board, pageposts=newest)
+    return await quart.render_template(
+        "board/board.html", board=board, pageposts=newest
+    )

--- a/blueprints/board/views.py
+++ b/blueprints/board/views.py
@@ -9,4 +9,4 @@ async def show_board(board: str):
     newest = await postgres.pool.fetch(
         "SELECT * FROM posts WHERE board <@ $1 ORDER BY timestamp DESC LIMIT 25", board
     )
-    return await quart.render_template("front_page.html", pageposts=newest)
+    return await quart.render_template("board/board.html", board=board, pageposts=newest)

--- a/static/index.css
+++ b/static/index.css
@@ -71,6 +71,10 @@ label {
     color: #888888;
 }
 
+.post-author code {
+    border: none;
+}
+
 .post-content {
     border: 2px solid black;
     border-radius: 6px;

--- a/templates/blank.html
+++ b/templates/blank.html
@@ -4,7 +4,8 @@
 {% macro user(u) %}<a href="{{ url_for("user.user_overview", user=u) }}">{{ u }}</a>{% endmacro %}
 {% macro post_authorline(post) %}
     <small class="post-author">
-        posted by {{ user(post.author) }} at {{ correct_date(post.timestamp) }} to <code>{{ post.board }}</code>
+        posted by {{ user(post.author) }} at {{ correct_date(post.timestamp) }} to
+        <a href="{{ url_for("board.show_board", board=post.board) }}"><code>{{ post.board }}</code></a>
     </small>
 {% endmacro %}
 {% macro post_display(post, wrap=true) %}

--- a/templates/board/board.html
+++ b/templates/board/board.html
@@ -1,0 +1,2 @@
+{% extends "front_page.html" %}
+{% block title %}{{ board }} - better than memes{% endblock %}

--- a/templates/board/creation.html
+++ b/templates/board/creation.html
@@ -1,0 +1,14 @@
+{% extends "blank.html" %}
+{% block title %}create board{% endblock %}
+{% block body %}
+    <form method="post" action="{{ url_for("board.create_board") }}">
+        <fieldset>
+            <legend>create board</legend>
+            <label>board path<br><input name="path" required></label>
+            {% for message in get_flashed_messages() %}
+                {{ message|safe }}<br>
+            {% endfor %}
+            <input type="submit" value="create board">
+        </fieldset>
+    </form>
+{% endblock %}


### PR DESCRIPTION
The not-ever-complete to-do here is:
* [ ] Front-end changes
  * [x] A view to see all posts in a board and child boards (`SELECT ... FROM posts WHERE board <@ view`) (done in 23048d0)
  * [x] Link to board view from post displays (done in c412fcd, needs better CSS)
  * [ ] 🥧 Reasonable markdown for quickly linking a board (perhaps `<board.name.here>`?)
* [x] Board creation (either a board exists because there is a post in it, or you can post to a board because it exists. Which one?)

At some point, I'd _love_ to be able to have stuff like board CSS, sidebars, basically steal more stuff from reddit. But that's going to take a while and is out of scope for now.